### PR TITLE
Made internal functions for the computation available without decorator

### DIFF
--- a/v6-summary-py/partial_summary.py
+++ b/v6-summary-py/partial_summary.py
@@ -27,7 +27,7 @@ def summary_per_data_station(
     is_numeric: list[bool] | None = None,
 ) -> dict:
     """
-    Compuate the summary statistics for a single data station to share with the
+    Compute the summary statistics for a single data station to share with the
     aggregator part of the algorithm
 
     Parameters
@@ -47,10 +47,18 @@ def summary_per_data_station(
         The summary statistics for the data station. If the summary statistics cannot
         be computed, None is returned
     """
+    return _summary_per_data_station(df, columns, is_numeric)
+
+
+def _summary_per_data_station(
+    df: pd.DataFrame,
+    columns: list[str] | None = None,
+    is_numeric: list[bool] | None = None,
+) -> dict:
     if not columns:
         columns = df.columns
 
-    # Check that columnn names exist in the dataframe
+    # Check that column names exist in the dataframe
     if not all([col in df.columns for col in columns]):
         non_existing_columns = [col for col in columns if col not in df.columns]
         raise InputError(

--- a/v6-summary-py/partial_variance.py
+++ b/v6-summary-py/partial_variance.py
@@ -38,12 +38,18 @@ def variance_per_data_station(
     dict
         Contains the variance of the numeric columns
     """
+    return _variance_per_data_station(df, columns, means)
+
+
+def _variance_per_data_station(
+    df: pd.DataFrame, columns: list[str], means: list[float]
+) -> dict:
     if not get_env_var(
         EnvVarsAllowed.ALLOW_VARIANCE.value, default="true", as_type="bool"
     ):
         error("Node policies do not allow sharing the variance.")
         return None
-    # Check that columnn names exist in the dataframe - note that this check should
+    # Check that column names exist in the dataframe - note that this check should
     # not be necessary if a user runs the central task as is has already been checked
     # in that case
     if not all([col in df.columns for col in columns]):


### PR DESCRIPTION
This is useful when we want to decorate the functions differently. Or want to call them in a different sequence. Now this is a pain, see https://github.com/Franky-Codes-BV/v6-euracan-sarcoma-algorithms/blob/feature/add-summary-stats-per-var-and-cohort/v6-algorithm-wrapper-py/v6-algorithm-wrapper-py/__init__.py

Note that this is also needed for IDEA4RC.